### PR TITLE
docs: fix README install workflow and update package reference to v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,16 @@ up ctp provider install crossplane-contrib/provider-upjet-digitalocean:v0.1.0
 Alternatively, you can use declarative installation:
 ```
 cat <<EOF | kubectl apply -f -
+---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
   name: provider-upjet-digitalocean
+  # By default, the Provider pod installs in the same namespace as Crossplane (crossplane-system).
+  # https://docs.crossplane.io/latest/packages/providers/
 spec:
-  package: crossplane-contrib/provider-upjet-digitalocean:v0.1.0
+  # https://marketplace.upbound.io/providers/crossplane-contrib/provider-upjet-digitalocean/v0.3.0
+  package: xpkg.upbound.io/crossplane-contrib/provider-upjet-digitalocean:v0.3.0
 EOF
 ```
 


### PR DESCRIPTION
## Summary

Fixes the declarative installation example in the README:

- Add `---` YAML document separator before the Provider manifest
- Add comments pointing to Crossplane provider docs and Upbound marketplace
- Update package registry from `crossplane-contrib/...` to `xpkg.upbound.io/...`
- Bump version from `v0.1.0` to `v0.3.0`

## Attribution

This work was originally submitted by @condaatje in #62. Thank you @condaatje for the contribution!

We reached out twice (#62 (comment)) asking for a DCO sign-off but did not receive a response. Since the changes are correct and straightforward, we're moving forward by applying them here with a proper sign-off.

Closes #62